### PR TITLE
Added tooltipText property

### DIFF
--- a/src/core/ui/components/Button/Button.js
+++ b/src/core/ui/components/Button/Button.js
@@ -150,7 +150,7 @@ export const Button = ({
             {
                 !!tooltipText
                 && (
-                    <Badge className="TooltipText" text={tooltipText} size="xs" color="darkGray" />
+                    <Badge className="Button__tooltip-text" text={tooltipText} size="xs" color="darkGray" />
                 )
             }
         </StyledWrapper>

--- a/src/core/ui/components/Button/Button.js
+++ b/src/core/ui/components/Button/Button.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 
+import { Badge } from '../Badge';
 import { StyledWrapper } from './StyledWrapper';
-// import './Button.scss';
 
 const propTypes = {
     /**
@@ -46,6 +46,10 @@ const propTypes = {
      * If true Button has a transparent border
      */
     textOnly: PropTypes.bool,
+    /**
+     * Text content of `Button's tooltip`
+     */
+    tooltipText: PropTypes.string,
     type: PropTypes.oneOf(['button', 'submit', 'reset']),
 };
 
@@ -62,6 +66,7 @@ const defaultProps = {
     target: null,
     text: '',
     textOnly: false,
+    tooltipText: '',
     type: 'button',
 };
 
@@ -87,6 +92,7 @@ export const Button = ({
     shape,
     text,
     textOnly,
+    tooltipText,
     type,
     icon,
     iconAfterText,
@@ -141,6 +147,12 @@ export const Button = ({
     return (
         <StyledWrapper {...styledProps} {...calculatedProps}>
             {content}
+            {
+                !!tooltipText
+                && (
+                    <Badge className="TooltipText" text={tooltipText} size="xs" color="darkGray" />
+                )
+            }
         </StyledWrapper>
     );
 };

--- a/src/core/ui/components/Button/Button.js
+++ b/src/core/ui/components/Button/Button.js
@@ -31,7 +31,7 @@ const propTypes = {
     iconAfterText: PropTypes.bool,
     onClick: PropTypes.func,
     /**
-     * Renders the Button in different shapes (rectangle or circle) 
+     * Renders the `Button` in different shapes (rectangle or circle) 
      */
     shape: PropTypes.oneOf(['rectangle', 'circle']),
     /**
@@ -43,11 +43,11 @@ const propTypes = {
      */
     text: PropTypes.string,
     /**
-     * If true Button has a transparent border
+     * If true `Button` has a transparent border
      */
     textOnly: PropTypes.bool,
     /**
-     * Text content of `Button's tooltip`
+     * Text content of tooltip for the `Button`
      */
     tooltipText: PropTypes.string,
     type: PropTypes.oneOf(['button', 'submit', 'reset']),

--- a/src/core/ui/components/Button/Button.stories.js
+++ b/src/core/ui/components/Button/Button.stories.js
@@ -92,4 +92,12 @@ storiesOf('Button', module)
                 {'<Button icon={<FontAwesomeIcon icon={faTimes} />} textOnly />'}
             </Highlight>
         </>
+    ))
+    .add('with tooltipText', () => (
+        <>
+            <Button text="Hello world" tooltipText="Tooltip Text" />
+            <Highlight className="html">
+                {'<Button text="Hello world" tooltipText="Tooltip Text" />'}
+            </Highlight>
+        </>
     ));

--- a/src/core/ui/components/Button/Button.test.js
+++ b/src/core/ui/components/Button/Button.test.js
@@ -35,6 +35,11 @@ describe('Button', () => {
         expect(button).toMatchSnapshot();
     });
 
+    it('should render the button with tooltipText correctly', () => {
+        const button = renderer.create(<Button tooltipText="Testing tooltip text" />).toJSON();
+        expect(button).toMatchSnapshot();
+    });
+
     it('should have the correct default props', () => {
         const button = mount(<Button />);
         expect(button.prop('className')).toEqual('');
@@ -49,6 +54,7 @@ describe('Button', () => {
         expect(button.prop('text')).toEqual('');
         expect(button.prop('type')).toEqual('button');
         expect(button.prop('shape')).toEqual('rectangle');
+        expect(button.prop('tooltipText')).toEqual('');
     });
 
     it('should have the correct passed props', () => {
@@ -63,6 +69,7 @@ describe('Button', () => {
             target: 'test target',
             text: 'test text',
             textOnly: true,
+            tooltipText: 'test tooltip text',
             type: 'submit',
             shape: 'circle',
         };
@@ -79,6 +86,7 @@ describe('Button', () => {
         expect(button.prop('textOnly')).toEqual(true);
         expect(button.prop('type')).toEqual('submit');
         expect(button.prop('shape')).toEqual('circle');
+        expect(button.prop('tooltipText')).toEqual('test tooltip text');
     });
 
     it('should render the text', () => {
@@ -95,6 +103,24 @@ describe('Button', () => {
         };
         const button = mount(<Button {...props} />);
         expect(button.find('span').text()).toEqual('icon');
+    });
+
+    describe('when setting the textTooltip prop (default and custom value)', () => {
+        it('should not render the tooltip', () => {
+            const button = mount(<Button />);
+    
+            expect(button.find('div.TooltipText')).toHaveLength(0);
+        });
+
+        it('should render the tooltip text', () => {
+            const props = {
+                tooltipText: 'test tooltip text',
+            };
+            const button = mount(<Button {...props} />);
+    
+            expect(button.find('div.TooltipText')).toHaveLength(1);
+            expect(button.find('div.TooltipText').text()).toEqual('test tooltip text');
+        });
     });
 
     describe('when iconAfterText prop is default', () => {

--- a/src/core/ui/components/Button/Button.test.js
+++ b/src/core/ui/components/Button/Button.test.js
@@ -108,7 +108,7 @@ describe('Button', () => {
     describe('when setting the tooltipText prop (default and custom value)', () => {
         it('should not render the tooltip', () => {
             const button = mount(<Button />);
-    
+
             expect(button.find('div.Button__tooltip-text')).toHaveLength(0);
         });
 
@@ -117,7 +117,7 @@ describe('Button', () => {
                 tooltipText: 'test tooltip text',
             };
             const button = mount(<Button {...props} />);
-    
+
             expect(button.find('div.Button__tooltip-text')).toHaveLength(1);
             expect(button.find('div.Button__tooltip-text').text()).toEqual('test tooltip text');
         });

--- a/src/core/ui/components/Button/Button.test.js
+++ b/src/core/ui/components/Button/Button.test.js
@@ -105,11 +105,11 @@ describe('Button', () => {
         expect(button.find('span').text()).toEqual('icon');
     });
 
-    describe('when setting the textTooltip prop (default and custom value)', () => {
+    describe('when setting the tooltipText prop (default and custom value)', () => {
         it('should not render the tooltip', () => {
             const button = mount(<Button />);
     
-            expect(button.find('div.TooltipText')).toHaveLength(0);
+            expect(button.find('div.Button__tooltip-text')).toHaveLength(0);
         });
 
         it('should render the tooltip text', () => {
@@ -118,8 +118,8 @@ describe('Button', () => {
             };
             const button = mount(<Button {...props} />);
     
-            expect(button.find('div.TooltipText')).toHaveLength(1);
-            expect(button.find('div.TooltipText').text()).toEqual('test tooltip text');
+            expect(button.find('div.Button__tooltip-text')).toHaveLength(1);
+            expect(button.find('div.Button__tooltip-text').text()).toEqual('test tooltip text');
         });
     });
 

--- a/src/core/ui/components/Button/Button.test.js
+++ b/src/core/ui/components/Button/Button.test.js
@@ -108,7 +108,6 @@ describe('Button', () => {
     describe('when setting the tooltipText prop (default and custom value)', () => {
         it('should not render the tooltip', () => {
             const button = mount(<Button />);
-
             expect(button.find('div.Button__tooltip-text')).toHaveLength(0);
         });
 
@@ -117,7 +116,6 @@ describe('Button', () => {
                 tooltipText: 'test tooltip text',
             };
             const button = mount(<Button {...props} />);
-
             expect(button.find('div.Button__tooltip-text')).toHaveLength(1);
             expect(button.find('div.Button__tooltip-text').text()).toEqual('test tooltip text');
         });

--- a/src/core/ui/components/Button/StyledWrapper.js
+++ b/src/core/ui/components/Button/StyledWrapper.js
@@ -43,15 +43,16 @@ export const StyledWrapper = styled(({
             ` : ''}
         }
     `}
-    .TooltipText {
+
+    .Button__tooltip-text {
         display: none;
         position: absolute;
         margin-left: 20px;
     }
 
     &:hover {
-        .TooltipText {
-            display: unset;
+        .Button__tooltip-text {
+            display: inline-block;
         }
     }
 

--- a/src/core/ui/components/Button/StyledWrapper.js
+++ b/src/core/ui/components/Button/StyledWrapper.js
@@ -8,6 +8,7 @@ export const StyledWrapper = styled(({
     full,
     ghost,
     shape,
+    textOnly,
     ...rest
 }) => <button {...rest} />)`
     position: relative;

--- a/src/core/ui/components/Button/StyledWrapper.js
+++ b/src/core/ui/components/Button/StyledWrapper.js
@@ -10,6 +10,7 @@ export const StyledWrapper = styled(({
     shape,
     ...rest
 }) => <button {...rest} />)`
+    position: relative;
     border: 1px solid;
     display: inline-block;
     font-size: ${typography.fontSm};
@@ -42,6 +43,17 @@ export const StyledWrapper = styled(({
             ` : ''}
         }
     `}
+    .TooltipText {
+        display: none;
+        position: absolute;
+        margin-left: 20px;
+    }
+
+    &:hover {
+        .TooltipText {
+            display: unset;
+        }
+    }
 
     // If buttons follow each other in a row
     // set a standardized whitespace between them

--- a/src/core/ui/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/core/ui/components/Button/__snapshots__/Button.test.js.snap
@@ -1,12 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button should render the circle shaped button correctly 1`] = `
+exports[`Button should render the button with tooltipText correctly 1`] = `
 <button
-  className="Button circle full only-icon sc-bdVaJa bDQvHA"
+  className="Button rectangle full only-icon sc-bwzfXH jcWJnl"
   disabled={false}
   id={null}
   onClick={[Function]}
-  textOnly={false}
+  type="button"
+>
+  <span>
+    
+  </span>
+  <div
+    className="Badge Button__tooltip-text darkGray xs sc-bdVaJa jCQAeT"
+    color="darkGray"
+    size="xs"
+  >
+    Testing tooltip text
+  </div>
+</button>
+`;
+
+exports[`Button should render the circle shaped button correctly 1`] = `
+<button
+  className="Button circle full only-icon sc-bwzfXH yPbHY"
+  disabled={false}
+  id={null}
+  onClick={[Function]}
   type="button"
 >
   <span>
@@ -17,11 +37,10 @@ exports[`Button should render the circle shaped button correctly 1`] = `
 
 exports[`Button should render the default button correctly 1`] = `
 <button
-  className="Button rectangle full only-icon sc-bdVaJa lgwUeo"
+  className="Button rectangle full only-icon sc-bwzfXH jcWJnl"
   disabled={false}
   id={null}
   onClick={[Function]}
-  textOnly={false}
   type="button"
 >
   <span>
@@ -32,11 +51,10 @@ exports[`Button should render the default button correctly 1`] = `
 
 exports[`Button should render the disabled button correctly 1`] = `
 <button
-  className="Button rectangle full disabled only-icon sc-bdVaJa ddsYBn"
+  className="Button rectangle full disabled only-icon sc-bwzfXH jUCEme"
   disabled={true}
   id={null}
   onClick={[Function]}
-  textOnly={false}
   type="button"
 >
   <span>
@@ -47,11 +65,10 @@ exports[`Button should render the disabled button correctly 1`] = `
 
 exports[`Button should render the ghost and disabled button correctly 1`] = `
 <button
-  className="Button rectangle disabled ghost only-icon sc-bdVaJa jjjiUC"
+  className="Button rectangle disabled ghost only-icon sc-bwzfXH gnelvu"
   disabled={true}
   id={null}
   onClick={[Function]}
-  textOnly={false}
   type="button"
 >
   <span>
@@ -62,11 +79,10 @@ exports[`Button should render the ghost and disabled button correctly 1`] = `
 
 exports[`Button should render the ghost button correctly 1`] = `
 <button
-  className="Button rectangle ghost only-icon sc-bdVaJa hWvMox"
+  className="Button rectangle ghost only-icon sc-bwzfXH krBWiP"
   disabled={false}
   id={null}
   onClick={[Function]}
-  textOnly={false}
   type="button"
 >
   <span>
@@ -77,11 +93,10 @@ exports[`Button should render the ghost button correctly 1`] = `
 
 exports[`Button should render the textOnly and ghost button correctly 1`] = `
 <button
-  className="Button rectangle textOnly only-icon sc-bdVaJa gqBtTO"
+  className="Button rectangle textOnly only-icon sc-bwzfXH cWYKEJ"
   disabled={false}
   id={null}
   onClick={[Function]}
-  textOnly={true}
   type="button"
 >
   <span>


### PR DESCRIPTION
* Extended the Button component to accept a prop "tooltipText" which when set prints a Badge which is then used as the container for the tooltip text
Button improvements

* Changed the tooltip to use the darkGray colour for better contrast
Button improvements

* Adjusted the props mapping to display the tooltipText value
* Adjusted the unit tests to cover the tooltip
* Updated snapshots

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/comatch/comatch-ui/12)
<!-- Reviewable:end -->
