### PR TITLE
React Select problem fix (Yiotis)

### DIFF
--- a/src/core/ui/components/Autocomplete/Autocomplete.js
+++ b/src/core/ui/components/Autocomplete/Autocomplete.js
@@ -181,6 +181,7 @@ class Autocomplete extends Component {
                     isLoading={isLoading}
                     loadingMessage={loadingMessage}
                     menuIsOpen={focused && !!inputValue}
+                    menuPortalTarget={document.body}
                     name={name}
                     noOptionsMessage={noOptionsMessage}
                     onBlur={handleBlur}

--- a/src/core/ui/components/Autocomplete/react-select-styles.js
+++ b/src/core/ui/components/Autocomplete/react-select-styles.js
@@ -43,6 +43,10 @@ export const customStyles = {
         borderBottomRightRadius: '3px',
         marginTop: 0,
     }),
+    menuPortal: (provided) => ({
+        ...provided,
+        zIndex: 4,
+    }),
     option: (provided, state) => ({
         ...provided,
         backgroundColor: state.isFocused ? optionColor : palette.white,

--- a/src/core/ui/components/MultiSelectInput/MultiSelectInput.js
+++ b/src/core/ui/components/MultiSelectInput/MultiSelectInput.js
@@ -90,6 +90,7 @@ export const MultiSelectInput = ({
                 isMulti
                 className="MultiSelectInput__input"
                 isDisabled={disabled}
+                menuPortalTarget={document.body}
                 name={name}
                 onBlur={onBlur}
                 onChange={handleChange}

--- a/src/core/ui/components/MultiSelectInput/custom-styles.js
+++ b/src/core/ui/components/MultiSelectInput/custom-styles.js
@@ -36,6 +36,10 @@ export const customStyles = {
         borderBottomRightRadius: 3,
         marginTop: 0,
     }),
+    menuPortal: (provided) => ({
+        ...provided,
+        zIndex: 4,
+    }),
     option: (provided, state) => ({
         ...provided,
         backgroundColor: state.isFocused ? palette.lightGray : palette.white,


### PR DESCRIPTION
* When there is more than one react select next to each other, the last one will always overlap over the previous. This is a fix for this problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/comatch/comatch-ui/62)
<!-- Reviewable:end -->
