### PR TITLE
[RUM-531] Fix jest prop type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
         "file-loader": "^4.0.0",
         "jest": "^24.8.0",
         "jest-coverage-badges": "^1.1.2",
+        "jest-prop-type-error": "^1.1.0",
         "prettier": "^1.17.0",
+        "prop-types": "^15.7.2",
         "react-docgen": "^2.21.0",
         "react-docgen-markdown-renderer": "^1.1.0",
         "react-test-renderer": "16.9.0",
@@ -92,6 +94,9 @@
             "json-summary",
             "text",
             "lcov"
+        ],
+        "setupFiles": [
+            "jest-prop-type-error"
         ]
     }
 }

--- a/src/core/ui/components/CheckboxGroupInput/CheckboxGroupInput.test.js
+++ b/src/core/ui/components/CheckboxGroupInput/CheckboxGroupInput.test.js
@@ -51,7 +51,7 @@ describe('CheckboxGroupInput', () => {
 
         const checkBoxGroupWithNodeTitle = renderer
             .create(
-                <CheckboxGroupInput name="checkbox-sample-name" options={options} label={<span>sample-label</span>} />,
+                <CheckboxGroupInput name="checkbox-sample-name" options={options} title='sample-title' />,
             )
             .toJSON();
 
@@ -64,7 +64,7 @@ describe('CheckboxGroupInput', () => {
                 <CheckboxGroupInput
                     name="checkbox-sample-name"
                     options={options}
-                    label={<span>sample-label</span>}
+                    label='sample-label'
                     required={true}
                 />,
             )

--- a/src/core/ui/components/CheckboxGroupInput/__snapshots__/CheckboxGroupInput.test.js.snap
+++ b/src/core/ui/components/CheckboxGroupInput/__snapshots__/CheckboxGroupInput.test.js.snap
@@ -705,15 +705,7 @@ exports[`CheckboxGroupInput should render with label/title correctly 2`] = `
   className="Input CheckboxGroupInput per-row-1 sc-ifAKCX hkLpQG"
   id={null}
 >
-  <label
-    className="InputLabel sc-bdVaJa iThGRf"
-    htmlFor={null}
-    id={null}
-  >
-    <span>
-      sample-label
-    </span>
-  </label>
+  
   <div
     className="Input CheckboxInput block sc-bxivhb bJyOBc"
     id={null}
@@ -814,9 +806,7 @@ exports[`CheckboxGroupInput should render with with label/title and required '*'
     htmlFor={null}
     id={null}
   >
-    <span>
-      sample-label
-    </span>
+    sample-label
     *
   </label>
   <div

--- a/src/core/ui/components/ProgressBar/ProgressBar.js
+++ b/src/core/ui/components/ProgressBar/ProgressBar.js
@@ -34,6 +34,7 @@ const defaultProps = {
     labelPosition: 'right',
     progressiveColoring: false,
     progressLabel: '',
+    progress: 0,
     reverse: false,
     variant: 'standard',
 };

--- a/src/core/ui/components/ProgressBar/ProgressBar.test.js
+++ b/src/core/ui/components/ProgressBar/ProgressBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { create } from 'react-test-renderer';
+import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { ProgressBar } from './ProgressBar';
@@ -19,7 +19,7 @@ const props = {
 
 describe('ProgressBar', () => {
     it('should render correctly', () => {
-        const wrapper = create(<ProgressBar />).toJSON();
+        const wrapper = renderer.create(<ProgressBar />).toJSON();
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/core/ui/components/ProgressBar/__snapshots__/ProgressBar.test.js.snap
+++ b/src/core/ui/components/ProgressBar/__snapshots__/ProgressBar.test.js.snap
@@ -18,7 +18,7 @@ exports[`ProgressBar should render correctly 1`] = `
       className="ProgressBar__progress"
       style={
         Object {
-          "transform": "scaleX(NaN)",
+          "transform": "scaleX(0)",
         }
       }
     />
@@ -26,11 +26,11 @@ exports[`ProgressBar should render correctly 1`] = `
       className="ProgressBar__progress-label"
       style={
         Object {
-          "left": "calc(undefined% + 8px)",
+          "left": "calc(0% + 8px)",
         }
       }
     >
-      undefined%
+      0%
     </div>
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6655,6 +6655,11 @@ jest-pnp-resolver@^1.2.1:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
+jest-prop-type-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz#7949a73cef6b9769ed9811139933b4139d2d8ad9"
+  integrity sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==
+
 jest-regex-util@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.3.0.tgz#d5a65f60be1ae3e310d5214a0307581995227b36"


### PR DESCRIPTION
Hello, Team! 

This PR about fixing jest prop type errors e.g.:
![image](https://user-images.githubusercontent.com/13170022/64019804-6aab7100-cb30-11e9-8fa6-87087303fa5a.png)
![image](https://user-images.githubusercontent.com/13170022/64019828-7c8d1400-cb30-11e9-9d8d-5ed97aa594b6.png)

To better handle such kind of errors in the future I installed:
https://www.npmjs.com/package/jest-prop-type-error
‘jest-prop-type-error’

Plus noticed that we missed `prop-types`, also was added
https://www.npmjs.com/package/prop-types

Best 
Zhenja
