### PR TITLE
Invert password show/hide icon

### DIFF
--- a/src/core/ui/components/PasswordInput/PasswordInput.js
+++ b/src/core/ui/components/PasswordInput/PasswordInput.js
@@ -19,7 +19,7 @@ export class PasswordInput extends Component {
         const type = this.state.show ? 'text' : 'password';
         const icon = (
             <span onClick={this.handleIconClick} className="TextInput__icon clickable">
-                <FontAwesomeIcon icon={this.state.show ? faEye : faEyeSlash} />
+                <FontAwesomeIcon icon={this.state.show ? faEyeSlash : faEye} />
             </span>
         );
 


### PR DESCRIPTION
Request from Rafaela: the password input should the "eye open" icon when the text is hidden, and show the "eye closed" icon when the text is shown. The new logic is the same used by GMail. 